### PR TITLE
Improve color palette

### DIFF
--- a/components/dialog/accumulated/viewAccumulatedResultDialog.vue
+++ b/components/dialog/accumulated/viewAccumulatedResultDialog.vue
@@ -24,7 +24,7 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Close</v-btn>
+        <Button variant="text" @click="close()">Close</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -32,10 +32,12 @@
 
 <script>
 import ViewAccumulatedResultInterface from '~/components/interface/viewAccumulatedResultInterface.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     ViewAccumulatedResultInterface,
+    Button,
   },
 
   props: {

--- a/components/dialog/auth/loginDialog.vue
+++ b/components/dialog/auth/loginDialog.vue
@@ -3,7 +3,7 @@
     <v-toolbar color="primary" dark flat>
       <v-toolbar-title>{{ loginMode ? 'Login' : 'Register' }}</v-toolbar-title>
       <v-spacer></v-spacer>
-      <v-btn text @click="goToWcaAuth()">
+      <Button variant="text" @click="goToWcaAuth()">
         <img
           src="~static/WCAlogo_notext.svg"
           alt=""
@@ -11,10 +11,10 @@
           class="pr-2"
         />
         WCA Login
-      </v-btn>
-      <v-btn text @click="loginMode = !loginMode">{{
+      </Button>
+      <Button variant="text" @click="loginMode = !loginMode">{{
         loginMode ? 'Register' : 'Login'
-      }}</v-btn>
+      }}</Button>
     </v-toolbar>
     <LoginInterface v-if="loginMode" @login-success="close()"></LoginInterface>
     <RegisterInterface v-else @login-success="close()"></RegisterInterface>
@@ -25,11 +25,13 @@
 import authService from '~/services/auth.js'
 import LoginInterface from '~/components/interface/auth/loginInterface.vue'
 import RegisterInterface from '~/components/interface/auth/registerInterface.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     LoginInterface,
     RegisterInterface,
+    Button,
   },
 
   props: {

--- a/components/dialog/competition/addCompetitionDialog.vue
+++ b/components/dialog/competition/addCompetitionDialog.vue
@@ -107,12 +107,9 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn
-          color="primary"
-          :loading="loading.addCompetition"
-          @click="submit()"
-          >Submit</v-btn
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button :loading="loading.addCompetition" @click="submit()"
+          >Submit</Button
         >
       </v-card-actions>
     </v-card>
@@ -122,9 +119,10 @@
 <script>
 import sharedService from '~/services/shared.js'
 import { CREATE_COMPETITION_MUTATION } from '~/gql/mutation/competition.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
-  components: {},
+  components: { Button },
 
   props: {
     status: {

--- a/components/dialog/competition/editCompetitionDialog.vue
+++ b/components/dialog/competition/editCompetitionDialog.vue
@@ -110,12 +110,13 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn
+        <Button variant="text" text @click="close()">Cancel</Button>
+        <Button
+          variant="text"
           color="primary"
           :loading="loading.editCompetition"
           @click="submit()"
-          >Submit</v-btn
+          >Submit</Button
         >
       </v-card-actions>
     </v-card>
@@ -126,8 +127,12 @@
 import sharedService from '~/services/shared.js'
 import { UPDATE_COMPETITION_MUTATION } from '~/gql/mutation/competition.js'
 import { COMPETITION_BASIC_QUERY } from '~/gql/query/competition.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  components: {
+    Button,
+  },
   props: {
     status: {
       type: Boolean,

--- a/components/dialog/competitionRound/addCompetitionRoundDialog.vue
+++ b/components/dialog/competitionRound/addCompetitionRoundDialog.vue
@@ -39,12 +39,12 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button
           color="primary"
           :loading="loading.addCompetitionRound"
           @click="submit()"
-          >Add</v-btn
+          >Add</Button
         >
       </v-card-actions>
     </v-card>
@@ -56,10 +56,12 @@ import sharedService from '~/services/shared.js'
 import { ADD_COMPETITION_ROUND } from '~/gql/mutation/competition.js'
 import { EVENTS_QUERY } from '~/gql/query/event.js'
 import EventLabel from '~/components/shared/eventLabel.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     EventLabel,
+    Button,
   },
 
   props: {
@@ -68,7 +70,7 @@ export default {
     },
     competition: {
       required: true,
-    }
+    },
   },
 
   data() {

--- a/components/dialog/competitionRound/deleteCompetitionRoundDialog.vue
+++ b/components/dialog/competitionRound/deleteCompetitionRoundDialog.vue
@@ -14,13 +14,13 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button
+          variant="text"
           color="error"
-          text
           :loading="loading.deleteCompetitionRound"
           @click="deleteCompetitionRound()"
-          >Delete</v-btn
+          >Delete</Button
         >
       </v-card-actions>
     </v-card>
@@ -30,8 +30,12 @@
 <script>
 import sharedService from '~/services/shared.js'
 import { REMOVE_COMPETITION_ROUND } from '~/gql/mutation/competition.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  competition: {
+    Button,
+  },
   props: {
     status: {
       type: Boolean,

--- a/components/dialog/misc/editRoomSettingsDialog.vue
+++ b/components/dialog/misc/editRoomSettingsDialog.vue
@@ -84,16 +84,18 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn color="primary" @click="submit()">Apply</v-btn>
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button @click="submit()">Apply</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
 <script>
+import Button from '~/components/shared/button.vue'
+
 export default {
-  components: {},
+  components: { Button },
 
   props: {
     status: {

--- a/components/dialog/misc/viewInstructionsDialog.vue
+++ b/components/dialog/misc/viewInstructionsDialog.vue
@@ -17,14 +17,19 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Close</v-btn>
+        <Button variant="text" @click="close()">Close</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
 <script>
+import Button from '~/components/shared/button.vue'
+
 export default {
+  components: {
+    Button,
+  },
   props: {
     status: {
       type: Boolean,

--- a/components/dialog/organisation/addOrganisationDialog.vue
+++ b/components/dialog/organisation/addOrganisationDialog.vue
@@ -56,12 +56,9 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn
-          color="primary"
-          :loading="loading.addOrganisation"
-          @click="submit()"
-          >Submit</v-btn
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button :loading="loading.addOrganisation" @click="submit()"
+          >Submit</Button
         >
       </v-card-actions>
     </v-card>
@@ -71,9 +68,10 @@
 <script>
 import sharedService from '~/services/shared.js'
 import { CREATE_ORGANISATION_MUTATION } from '~/gql/mutation/organisation.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
-  components: {},
+  components: { Button },
 
   props: {
     status: {

--- a/components/dialog/organisation/editOrganisationDialog.vue
+++ b/components/dialog/organisation/editOrganisationDialog.vue
@@ -59,12 +59,9 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn
-          color="primary"
-          :loading="loading.editOrganisation"
-          @click="submit()"
-          >Submit</v-btn
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button :loading="loading.editOrganisation" @click="submit()"
+          >Submit</Button
         >
       </v-card-actions>
     </v-card>
@@ -75,8 +72,10 @@
 import sharedService from '~/services/shared.js'
 import { UPDATE_ORGANISATION_MUTATION } from '~/gql/mutation/organisation.js'
 import { ORGANISATION_BASIC_QUERY } from '~/gql/query/organisation.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  components: { Button },
   props: {
     status: {
       type: Boolean,

--- a/components/dialog/room/addRoomDialog.vue
+++ b/components/dialog/room/addRoomDialog.vue
@@ -107,10 +107,8 @@
         ></v-switch>
         -->
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn color="primary" :loading="loading.addRoom" @click="submit()"
-          >Submit</v-btn
-        >
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button :loading="loading.addRoom" @click="submit()">Submit</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -121,10 +119,12 @@ import sharedService from '~/services/shared.js'
 import { CREATE_ROOM_MUTATION } from '~/gql/mutation/room.js'
 import { EVENTS_QUERY } from '~/gql/query/event.js'
 import EventLabel from '~/components/shared/eventLabel.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     EventLabel,
+    Button,
   },
 
   props: {

--- a/components/dialog/room/deleteRoomDialog.vue
+++ b/components/dialog/room/deleteRoomDialog.vue
@@ -12,13 +12,13 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button
+          variant="text"
           color="error"
-          text
           :loading="loading.deleteRoom"
           @click="deleteRoom()"
-          >Delete</v-btn
+          >Delete</Button
         >
       </v-card-actions>
     </v-card>
@@ -28,8 +28,10 @@
 <script>
 import sharedService from '~/services/shared.js'
 import { DELETE_ROOM_MUTATION } from '~/gql/mutation/room.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  components: { Button },
   props: {
     status: {
       type: Boolean,

--- a/components/dialog/room/editRoomDialog.vue
+++ b/components/dialog/room/editRoomDialog.vue
@@ -73,10 +73,8 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn color="primary" :loading="loading.editRoom" @click="submit()"
-          >Submit</v-btn
-        >
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button :loading="loading.editRoom" @click="submit()">Submit</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -86,8 +84,10 @@
 import sharedService from '~/services/shared.js'
 import { UPDATE_ROOM_MUTATION } from '~/gql/mutation/room.js'
 import { ROOM_BASIC_QUERY } from '~/gql/query/room.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  components: { Button },
   props: {
     status: {
       type: Boolean,

--- a/components/dialog/room/inputRoomSecretDialog.vue
+++ b/components/dialog/room/inputRoomSecretDialog.vue
@@ -19,10 +19,8 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn color="primary" :disabled="loading.submit" @click="submit()"
-          >Submit</v-btn
-        >
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button :disabled="loading.submit" @click="submit()">Submit</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -30,8 +28,10 @@
 
 <script>
 import sharedService from '~/services/shared.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  components: { Button },
   props: {
     status: {
       type: Boolean,

--- a/components/dialog/room/untrackRoomSolvesDialog.vue
+++ b/components/dialog/room/untrackRoomSolvesDialog.vue
@@ -13,13 +13,13 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Cancel</v-btn>
-        <v-btn
+        <Button variant="text" @click="close()">Cancel</Button>
+        <Button
+          variant="text"
           color="error"
-          text
           :loading="loading.untrackRoomSolves"
           @click="untrackRoomSolves()"
-          >Confirm</v-btn
+          >Confirm</Button
         >
       </v-card-actions>
     </v-card>
@@ -29,8 +29,10 @@
 <script>
 import sharedService from '~/services/shared.js'
 import { UNTRACK_SOLVES_FROM_ROOM_MUTATION } from '~/gql/mutation/room.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  components: { Button },
   props: {
     status: {
       type: Boolean,

--- a/components/dialog/round/viewRoundDialog.vue
+++ b/components/dialog/round/viewRoundDialog.vue
@@ -20,7 +20,7 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Close</v-btn>
+        <Button variant="text" @click="close()">Close</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -28,10 +28,12 @@
 
 <script>
 import ViewRoundInterface from '~/components/interface/viewRoundInterface.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     ViewRoundInterface,
+    Button,
   },
 
   props: {

--- a/components/dialog/round/viewRoundsDialog.vue
+++ b/components/dialog/round/viewRoundsDialog.vue
@@ -20,7 +20,7 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Close</v-btn>
+        <Button variant="text" @click="close()">Close</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -28,10 +28,12 @@
 
 <script>
 import ViewRoundsInterface from '~/components/interface/viewRoundsInterface.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     ViewRoundsInterface,
+    Button,
   },
 
   props: {

--- a/components/dialog/solve/viewCuberSolvesDialog.vue
+++ b/components/dialog/solve/viewCuberSolvesDialog.vue
@@ -10,10 +10,10 @@
         <v-icon left>mdi-badge-account-horizontal</v-icon>
         <span class="headline">View Solves by {{ cuber.name }}</span>
         <v-spacer></v-spacer>
-        <v-btn text @click="openCuberProfile()">
+        <Button variant="text" @click="openCuberProfile()">
           <v-icon left>mdi-open-in-new</v-icon>
           Go To Cuber Profile
-        </v-btn>
+        </Button>
       </v-card-title>
 
       <v-card-text style="max-height: 600px;">
@@ -26,7 +26,7 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="close()">Close</v-btn>
+        <Button variant="text" @click="close()">Close</Button>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -34,10 +34,12 @@
 
 <script>
 import ViewCuberSolvesInterface from '~/components/interface/viewCuberSolvesInterface.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     ViewCuberSolvesInterface,
+    Button,
   },
 
   props: {

--- a/components/interface/auth/loginInterface.vue
+++ b/components/interface/auth/loginInterface.vue
@@ -20,13 +20,12 @@
       ></v-text-field>
     </v-card-text>
     <v-card-actions>
-      <v-btn text nuxt to="/password-reset">Password Forgotten</v-btn>
+      <Button variant="text" nuxt to="/password-reset"
+        >Password Forgotten</Button
+      >
       <v-spacer></v-spacer>
-      <v-btn
-        color="primary"
-        :loading="loading.submitting"
-        @click="handleSubmit()"
-        >Login</v-btn
+      <Button :loading="loading.submitting" @click="handleSubmit()"
+        >Login</Button
       >
     </v-card-actions>
   </v-card>
@@ -36,9 +35,10 @@
 import { LOGIN_MUTATION } from '~/gql/mutation/auth.js'
 import sharedService from '~/services/shared.js'
 import authService from '~/services/auth.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
-  components: {},
+  components: { Button },
 
   data() {
     return {

--- a/components/interface/auth/registerInterface.vue
+++ b/components/interface/auth/registerInterface.vue
@@ -44,11 +44,8 @@
     </v-card-text>
     <v-card-actions>
       <v-spacer></v-spacer>
-      <v-btn
-        color="primary"
-        :loading="loading.submitting"
-        @click="handleSubmit()"
-        >Create Account</v-btn
+      <Button :loading="loading.submitting" @click="handleSubmit()"
+        >Create Account</Button
       >
     </v-card-actions>
   </v-card>
@@ -58,9 +55,10 @@
 import { REGISTER_MUTATION } from '~/gql/mutation/auth.js'
 import sharedService from '~/services/shared.js'
 import authService from '~/services/auth.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
-  components: {},
+  components: { Button },
 
   data() {
     return {

--- a/components/overlay/cubeTimerOverlay.vue
+++ b/components/overlay/cubeTimerOverlay.vue
@@ -37,11 +37,12 @@
                   >(+{{ solveResult.penalties / 1000 }})</span
                 >
                 <div v-if="isInspectionDnf">
-                  Your solve was DNFed due to inspection taking longer than 17 seconds.
+                  Your solve was DNFed due to inspection taking longer than 17
+                  seconds.
                 </div>
                 <div v-else-if="isInspectionPenalty">
-                  Your solve has incurred an extra +2 penalty because the inspection
-                  took between 15 and 17 seconds.
+                  Your solve has incurred an extra +2 penalty because the
+                  inspection took between 15 and 17 seconds.
                 </div>
               </v-col>
             </v-row>
@@ -49,7 +50,9 @@
               <v-col cols="12" class="text-center" style="height: 16px;">
                 <div v-if="timerState == 1" class="overline">Inspecting</div>
                 <div v-else-if="timerState == 4" class="overline">Solving</div>
-                <div v-else-if="timerState == 5" class="overline">Verifying</div>
+                <div v-else-if="timerState == 5" class="overline">
+                  Verifying
+                </div>
               </v-col>
               <v-col cols="12" class="text-center">
                 <div v-if="inputMethod == 'manual'" class="overline">
@@ -66,25 +69,25 @@
             <v-row>
               <v-col cols="12" class="text-center" style="height: 36px;">
                 <template v-if="timerState == 5 || timerState == 6">
-                  <v-btn color="error" @click="toggleDnf()">
+                  <Button color="error" @click="toggleDnf()">
                     DNF
-                  </v-btn>
-                  <v-btn color="warning" @click="togglePenalty()">
+                  </Button>
+                  <Button color="warning" @click="togglePenalty()">
                     +2
-                  </v-btn>
-                  <v-btn
+                  </Button>
+                  <Button
                     color="success"
                     :loading="timerState == 6"
                     @click="timerState = 7"
                   >
                     Finalize Results (or hold Space)
-                  </v-btn>
+                  </Button>
                 </template>
-                <v-btn
+                <Button
                   v-else-if="timerState == 8"
                   color="warning"
                   @click="timerState = 9"
-                  >Go Back</v-btn
+                  >Go Back</Button
                 >
               </v-col>
             </v-row>
@@ -92,15 +95,16 @@
         </v-row>
       </v-layout>
     </v-container>
-
   </v-overlay>
 </template>
 
 <script>
 import sharedService from '~/services/shared.js'
 import Stackmat from '~/services/stackmat.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  components: { Button },
   props: {
     disabled: {},
 

--- a/components/popover/previewCuberPopover.vue
+++ b/components/popover/previewCuberPopover.vue
@@ -57,28 +57,27 @@
       <v-card-actions>
         <v-tooltip bottom>
           <template v-slot:activator="{ on }">
-            <v-btn icon v-on="on" @click="openCuberLookupDialog()">
+            <Button icon v-on="on" @click="openCuberLookupDialog()">
               <v-icon>mdi-badge-account-horizontal</v-icon>
-            </v-btn>
+            </Button>
           </template>
           <span>View Recent Solves</span>
         </v-tooltip>
 
         <v-tooltip bottom>
           <template v-slot:activator="{ on }">
-            <v-btn icon v-on="on" @click="openCuberProfile()">
+            <Button icon v-on="on" @click="openCuberProfile()">
               <v-icon>mdi-open-in-new</v-icon>
-            </v-btn>
+            </Button>
           </template>
           <span>Go to Profile</span>
         </v-tooltip>
         <v-spacer></v-spacer>
         <template v-if="cuber">
-          <v-btn
-            color="primary"
+          <Button
             :loading="loading.toggleFollow"
             @click="toggleFollowCuber(!cuber.is_followed_by_you)"
-            >{{ cuber.is_followed_by_you ? 'Un-Follow' : 'Follow' }}</v-btn
+            >{{ cuber.is_followed_by_you ? 'Un-Follow' : 'Follow' }}</Button
           >
         </template>
       </v-card-actions>
@@ -94,8 +93,10 @@ import {
   FOLLOW_CUBER_MUTATION,
   UNFOLLOW_CUBER_MUTATION,
 } from '~/gql/mutation/cuber.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
+  components: { Button },
   props: {
     selectedItem: {},
     chip: {

--- a/components/shared/button.vue
+++ b/components/shared/button.vue
@@ -41,22 +41,22 @@ export default {
     return {
       colorToTextColorMap: {
         dark: {
-          primary: '#121212',
-          secondary: '#121212',
+          primary: '#000',
+          secondary: '#000',
           accent: '#fff',
-          success: '#082218',
-          warning: '#2A150D',
-          error: '#0e0000',
-          info: '#050709',
+          success: '#000',
+          warning: '#000',
+          error: '#000',
+          info: '#000',
         },
         light: {
           primary: '#fff',
           secondary: '#fff',
-          accent: '#121212',
-          success: '#082218',
-          warning: '#2A150D',
-          error: '#0e0000',
-          info: '#050709',
+          accent: '#000',
+          success: '#000',
+          warning: '#000',
+          error: '#000',
+          info: '#000',
         },
       },
     }

--- a/components/shared/button.vue
+++ b/components/shared/button.vue
@@ -1,0 +1,98 @@
+<template>
+  <v-btn
+    v-bind="$attrs"
+    :color="icon ? undefined : inversed ? textColor : parsedColor"
+    :style="
+      !icon &&
+      parsedVariant === 'contained' && {
+        color: inversed ? parsedColor : textColor,
+      }
+    "
+    :outlined="parsedVariant === 'outlined'"
+    :text="parsedVariant === 'text'"
+    :icon="icon"
+    @click="$emit('click', $event)"
+  >
+    <slot />
+  </v-btn>
+</template>
+
+<script>
+export default {
+  props: {
+    color: {
+      type: String,
+      default: 'primary',
+    },
+    variant: {
+      type: String,
+      default: 'contained',
+    },
+    inversed: {
+      type: Boolean,
+      default: false,
+    },
+    icon: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      colorToTextColorMap: {
+        dark: {
+          primary: '#121212',
+          secondary: '#121212',
+          accent: '#fff',
+          success: '#082218',
+          warning: '#2A150D',
+          error: '#0e0000',
+          info: '#050709',
+        },
+        light: {
+          primary: '#fff',
+          secondary: '#fff',
+          accent: '#121212',
+          success: '#082218',
+          warning: '#2A150D',
+          error: '#0e0000',
+          info: '#050709',
+        },
+      },
+    }
+  },
+  computed: {
+    parsedVariant: function () {
+      return this.isAcceptedVariant(this.variant) ? this.variant : 'contained'
+    },
+    parsedColor: function () {
+      const color = this.isAcceptedColor(this.color) ? this.color : 'primary'
+      return this.$vuetify.theme.currentTheme[color]
+    },
+    textColor: function () {
+      const theme = this.$vuetify.theme.dark ? 'dark' : 'light'
+      const color = this.isAcceptedColor(this.color) ? this.color : 'primary'
+      return this.colorToTextColorMap[theme][color]
+    },
+  },
+
+  methods: {
+    isAcceptedColor: (color) => {
+      return (
+        color === 'primary' ||
+        color === 'secondary' ||
+        color === 'accent' ||
+        color === 'info' ||
+        color === 'success' ||
+        color === 'warning' ||
+        color === 'error'
+      )
+    },
+    isAcceptedVariant: (variant) => {
+      return (
+        variant === 'contained' || variant === 'outlined' || variant === 'text'
+      )
+    },
+  },
+}
+</script>

--- a/components/snackbar/cuberNotificationSnackbar.vue
+++ b/components/snackbar/cuberNotificationSnackbar.vue
@@ -30,9 +30,7 @@
           >
         </v-list-item-content>
       </v-list-item>
-      <v-btn color="primary" @click="joinRoom(currentNotification.room)"
-        >Join Room</v-btn
-      >
+      <Button @click="joinRoom(currentNotification.room)">Join Room</Button>
     </template>
     <template
       v-else-if="
@@ -58,10 +56,8 @@
           >
         </v-list-item-content>
       </v-list-item>
-      <v-btn
-        color="primary"
-        @click="openCuberProfile(currentNotification.initiator)"
-        >View Profile</v-btn
+      <Button @click="openCuberProfile(currentNotification.initiator)"
+        >View Profile</Button
       >
     </template>
     <template
@@ -88,24 +84,24 @@
           >
         </v-list-item-content>
       </v-list-item>
-      <v-btn color="primary" @click="joinRoom(currentNotification.room)"
-        >Join Room</v-btn
-      >
+      <Button @click="joinRoom(currentNotification.room)">Join Room</Button>
     </template>
-    <v-btn :style="{ color: textColor }" text @click="handleClose()">
+    <Button variant="text" @click="handleClose()">
       {{
         messagesCount > 1 ? 'Next (' + (messagesCount - 1) + ')' : 'Close'
-      }}</v-btn
+      }}</Button
     >
   </v-snackbar>
 </template>
 
-<script lang="ts">
+<script>
 import { mapGetters } from 'vuex'
+import Button from '../shared/button.vue'
 
 export default {
+  components: { Button },
   props: {
-    status: {}
+    status: {},
   },
   data() {
     return {

--- a/components/snackbar/snackbar.vue
+++ b/components/snackbar/snackbar.vue
@@ -1,14 +1,17 @@
 <template>
   <v-snackbar v-model="open" :timeout="3000" :color="variant">
     <span :style="{ color: textColor }">{{ message }}</span>
-    <v-btn :style="{ color: textColor }" text @click="open = false"
-      >Close</v-btn
+    <Button :color="variant" variant="text" inversed @click="open = false"
+      >Close</Button
     >
   </v-snackbar>
 </template>
 
-<script lang="ts">
+<script>
+import Button from '../shared/button.vue'
+
 export default {
+  components: { Button },
   data() {
     return {
       open: false,

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -44,9 +44,9 @@
             </v-list-item-action>
             <v-list-item-content></v-list-item-content>
             <v-list-item-action>
-              <v-btn icon @click.stop="miniVariant = !miniVariant">
+              <Button icon @click.stop="miniVariant = !miniVariant">
                 <v-icon>mdi-chevron-left</v-icon>
-              </v-btn>
+              </Button>
             </v-list-item-action>
           </v-list-item>
           <client-only>
@@ -219,7 +219,7 @@
         Terms and Conditions
       </nuxt-link>
       <v-spacer></v-spacer>
-      <v-btn small text @click="toggleTheme()">Toggle Theme</v-btn>
+      <Button variant="text" small @click="toggleTheme()">Toggle Theme</Button>
       <a href="mailto:feedback@cube.zone" class="pl-2">
         feedback@cube.zone
       </a>
@@ -266,6 +266,7 @@ import ViewCuberSolvesDialog from '~/components/dialog/solve/viewCuberSolvesDial
 import LoginDialog from '~/components/dialog/auth/loginDialog'
 import Snackbar from '~/components/snackbar/snackbar'
 import CuberNotificationSnackbar from '~/components/snackbar/cuberNotificationSnackbar'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
@@ -273,6 +274,7 @@ export default {
     Snackbar,
     CuberNotificationSnackbar,
     LoginDialog,
+    Button,
   },
   data() {
     return {

--- a/layouts/lite.vue
+++ b/layouts/lite.vue
@@ -9,7 +9,7 @@
       >
       <span>&nbsp;&copy; {{ new Date().getFullYear() }}</span>
       <v-spacer></v-spacer>
-      <v-btn small text @click="toggleTheme()">Toggle Theme</v-btn>
+      <Button variant="text" small @click="toggleTheme()">Toggle Theme</Button>
       <a href="mailto:feedback@cube.zone" class="pl-2">
         feedback@cube.zone
       </a>
@@ -30,10 +30,12 @@
 import { mapGetters } from 'vuex'
 import sharedService from '~/services/shared.js'
 import Snackbar from '~/components/snackbar/snackbar'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     Snackbar,
+    Button,
   },
   data() {
     return {}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -103,18 +103,18 @@ export default {
       dark: true,
       themes: {
         dark: {
-          primary: colors.blue.darken2,
+          primary: colors.blue.lighten2,
           accent: colors.grey.darken3,
-          secondary: colors.amber.darken3,
+          secondary: colors.purple.lighten2,
           info: colors.teal.lighten2,
           warning: colors.amber.base,
           error: colors.deepOrange.accent4,
           success: colors.green.accent3,
         },
         light: {
-          primary: colors.blue.lighten2,
+          primary: colors.blue.darken2,
           accent: colors.grey.lighten3,
-          secondary: colors.amber.lighten3,
+          secondary: colors.purple.darken2,
           info: colors.teal.lighten2,
           warning: colors.amber.base,
           error: colors.deepOrange.accent4,

--- a/pages/competition.vue
+++ b/pages/competition.vue
@@ -22,19 +22,14 @@
                   >Competition: {{ competition.name }}</v-toolbar-title
                 >
                 <v-divider class="mx-4" inset vertical></v-divider>
-                <v-btn
-                  color="primary"
-                  dark
-                  class="mb-2"
-                  @click="openAddCompetitionRoundDialog()"
-                >
+                <Button class="mb-2" @click="openAddCompetitionRoundDialog()">
                   <v-icon left>mdi-plus</v-icon>
                   New Round
-                </v-btn>
+                </Button>
                 <v-spacer></v-spacer>
-                <v-btn icon @click="reset()">
+                <Button icon @click="reset()">
                   <v-icon>mdi-refresh</v-icon>
-                </v-btn>
+                </Button>
               </v-toolbar>
               <v-expansion-panels>
                 <v-expansion-panel>
@@ -118,7 +113,9 @@
                       @click.stop="openEditCompetitionDialog(props.item)"
                       >mdi-pencil</v-icon
                     >
-                    <v-icon small @click.stop="openDeleteCompetitionRoundDialog(props.item)"
+                    <v-icon
+                      small
+                      @click.stop="openDeleteCompetitionRoundDialog(props.item)"
                       >mdi-delete</v-icon
                     >
                   </template>
@@ -129,15 +126,10 @@
               <div>
                 No rounds matched your filters
                 <br />
-                <v-btn
-                  color="primary"
-                  class="my-2"
-                  dark
-                  @click="openAddCompetitionRoundDialog()"
-                >
+                <Button class="my-2" @click="openAddCompetitionRoundDialog()">
                   <v-icon left>mdi-plus</v-icon>
                   Create a Round
-                </v-btn>
+                </Button>
               </div>
             </template>
           </v-data-table>
@@ -190,6 +182,7 @@ import AddCompetitionRoundDialog from '~/components/dialog/competitionRound/addC
 import EditCompetitionDialog from '~/components/dialog/competition/editCompetitionDialog.vue'
 import DeleteCompetitionRoundDialog from '~/components/dialog/competitionRound/deleteCompetitionRoundDialog.vue'
 import EventLabel from '~/components/shared/eventLabel.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
@@ -197,6 +190,7 @@ export default {
     EditCompetitionDialog,
     DeleteCompetitionRoundDialog,
     EventLabel,
+    Button,
   },
 
   data() {

--- a/pages/competitions.vue
+++ b/pages/competitions.vue
@@ -20,19 +20,14 @@
                 <v-icon left>mdi-account-group</v-icon>
                 <v-toolbar-title>Competitions</v-toolbar-title>
                 <v-divider class="mx-4" inset vertical></v-divider>
-                <v-btn
-                  color="primary"
-                  dark
-                  class="mb-2"
-                  @click="openAddCompetitionDialog()"
-                >
+                <Button class="mb-2" @click="openAddCompetitionDialog()">
                   <v-icon left>mdi-plus</v-icon>
                   New Competition
-                </v-btn>
+                </Button>
                 <v-spacer></v-spacer>
-                <v-btn icon @click="reset()">
+                <Button icon @click="reset()">
                   <v-icon>mdi-refresh</v-icon>
-                </v-btn>
+                </Button>
               </v-toolbar>
               <v-expansion-panels>
                 <v-expansion-panel>
@@ -169,15 +164,10 @@
               <div>
                 No competitions matched your filters
                 <br />
-                <v-btn
-                  color="primary"
-                  class="my-2"
-                  dark
-                  @click="openAddCompetitionDialog()"
-                >
+                <Button class="my-2" @click="openAddCompetitionDialog()">
                   <v-icon left>mdi-plus</v-icon>
                   Create a Competition
-                </v-btn>
+                </Button>
               </div>
             </template>
           </v-data-table>
@@ -215,6 +205,7 @@ import AddCompetitionDialog from '~/components/dialog/competition/addCompetition
 import EditCompetitionDialog from '~/components/dialog/competition/editCompetitionDialog.vue'
 import DeleteRoomDialog from '~/components/dialog/room/deleteRoomDialog.vue'
 import EventLabel from '~/components/shared/eventLabel.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
@@ -222,6 +213,7 @@ export default {
     EditCompetitionDialog,
     DeleteRoomDialog,
     EventLabel,
+    Button,
   },
 
   data() {

--- a/pages/cuber.vue
+++ b/pages/cuber.vue
@@ -12,11 +12,10 @@
               {{ cuber.name }}</v-toolbar-title
             >
             <v-divider class="mx-4" inset vertical></v-divider>
-            <v-btn
-              color="primary"
+            <Button
               :loading="loading.toggleFollow"
               @click="toggleFollowCuber(!cuber.is_followed_by_you)"
-              >{{ cuber.is_followed_by_you ? 'Un-Follow' : 'Follow' }}</v-btn
+              >{{ cuber.is_followed_by_you ? 'Un-Follow' : 'Follow' }}</Button
             >
             <template v-if="cuber.wca_id">
               <v-divider class="mx-4" inset vertical></v-divider>
@@ -54,9 +53,9 @@
               </span>
             </template>
             <v-spacer></v-spacer>
-            <v-btn icon @click="reset()">
+            <Button icon @click="reset()">
               <v-icon>mdi-refresh</v-icon>
-            </v-btn>
+            </Button>
           </v-toolbar>
           <v-tabs v-model="tab">
             <v-tab v-for="item in tabItems" :key="item.tab">
@@ -161,6 +160,7 @@ import ViewCuberRoomsInterface from '~/components/interface/viewCuberRoomsInterf
 import ViewCuberFollowersInterface from '~/components/interface/viewCuberFollowersInterface.vue'
 import ViewCuberFollowsInterface from '~/components/interface/viewCuberFollowsInterface.vue'
 import EventLabel from '~/components/shared/eventLabel.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
@@ -170,6 +170,7 @@ export default {
     ViewCuberFollowersInterface,
     ViewCuberFollowsInterface,
     EventLabel,
+    Button,
   },
 
   data() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,9 +31,9 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn color="primary" nuxt to="/rooms">
+          <Button nuxt to="/rooms">
             Get Started
-          </v-btn>
+          </Button>
         </v-card-actions>
       </v-card>
 
@@ -257,8 +257,10 @@
 </template>
 
 <script>
+import Button from '~/components/shared/button.vue'
+
 export default {
-  components: {},
+  components: { Button },
 
   methods: {},
   head() {

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -5,7 +5,7 @@
         <v-toolbar color="primary" dark flat>
           <v-toolbar-title>Login</v-toolbar-title>
           <v-spacer></v-spacer>
-          <v-btn text @click="goToWcaAuth()">
+          <Button variant="text" @click="goToWcaAuth()">
             <img
               src="../static/WCAlogo_notext.svg"
               alt=""
@@ -13,8 +13,8 @@
               class="pr-2"
             />
             WCA Login
-          </v-btn>
-          <v-btn text nuxt to="/register">Register</v-btn>
+          </Button>
+          <Button variant="text" nuxt to="/register">Register</Button>
         </v-toolbar>
         <LoginInterface @login-success="handleLoginSuccess"></LoginInterface>
       </v-flex>
@@ -25,11 +25,13 @@
 <script>
 import authService from '~/services/auth.js'
 import LoginInterface from '~/components/interface/auth/loginInterface.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   middleware: 'router-auth',
   components: {
     LoginInterface,
+    Button,
   },
 
   data() {

--- a/pages/my-rooms.vue
+++ b/pages/my-rooms.vue
@@ -14,15 +14,15 @@
               inset
               vertical
             ></v-divider>
-            <v-btn color="primary" dark class="mb-2" @click="openAddRoomDialog()">
+            <Button class="mb-2" @click="openAddRoomDialog()">
               <v-icon left>mdi-plus</v-icon>
               New Room
-            </v-btn>
+            </Button>
             -->
             <v-spacer></v-spacer>
-            <v-btn icon @click="reset()">
+            <Button icon @click="reset()">
               <v-icon>mdi-refresh</v-icon>
-            </v-btn>
+            </Button>
           </v-toolbar>
 
           <ViewCuberRoomsInterface
@@ -46,11 +46,13 @@
 import ViewCuberRoomsInterface from '~/components/interface/viewCuberRoomsInterface.vue'
 import AddRoomDialog from '~/components/dialog/room/addRoomDialog.vue'
 import { mapGetters } from 'vuex'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     ViewCuberRoomsInterface,
     AddRoomDialog,
+    Button,
   },
 
   data() {

--- a/pages/organisations.vue
+++ b/pages/organisations.vue
@@ -20,19 +20,14 @@
                 <v-icon left>mdi-domain</v-icon>
                 <v-toolbar-title>My Organisations</v-toolbar-title>
                 <v-divider class="mx-4" inset vertical></v-divider>
-                <v-btn
-                  color="primary"
-                  dark
-                  class="mb-2"
-                  @click="openAddOrganisationDialog()"
-                >
+                <Button class="mb-2" @click="openAddOrganisationDialog()">
                   <v-icon left>mdi-plus</v-icon>
                   New Organisation
-                </v-btn>
+                </Button>
                 <v-spacer></v-spacer>
-                <v-btn icon @click="reset()">
+                <Button icon @click="reset()">
                   <v-icon>mdi-refresh</v-icon>
-                </v-btn>
+                </Button>
               </v-toolbar>
             </template>
             <template v-slot:item="props">
@@ -92,17 +87,18 @@
 </template>
 
 <script>
-import sharedService from '~/services/shared.js'
 import { booleanOptionsArray } from '~/services/constants.js'
 import { ORGANISATIONS_QUERY } from '~/gql/query/organisation.js'
 
 import AddOrganisationDialog from '~/components/dialog/organisation/addOrganisationDialog.vue'
 import EditOrganisationDialog from '~/components/dialog/organisation/editOrganisationDialog.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     AddOrganisationDialog,
     EditOrganisationDialog,
+    Button,
   },
 
   data() {

--- a/pages/password-reset.vue
+++ b/pages/password-reset.vue
@@ -6,7 +6,7 @@
           <v-toolbar color="primary" dark flat>
             <v-toolbar-title>Reset Password</v-toolbar-title>
             <v-spacer></v-spacer>
-            <v-btn text nuxt to="/login">Login</v-btn>
+            <Button variant="text" nuxt to="/login">Login</Button>
           </v-toolbar>
           <v-card-text>
             <v-text-field
@@ -19,11 +19,8 @@
           </v-card-text>
           <v-card-actions>
             <v-spacer></v-spacer>
-            <v-btn
-              color="primary"
-              :disabled="loading.submitting"
-              @click="handleSubmit()"
-              >Reset Password</v-btn
+            <Button :disabled="loading.submitting" @click="handleSubmit()"
+              >Reset Password</Button
             >
           </v-card-actions>
         </v-card>
@@ -35,11 +32,12 @@
 <script>
 import { FORGOT_PASSWORD_MUTATION } from '~/gql/mutation/auth.js'
 import sharedService from '~/services/shared.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
   middleware: 'router-auth',
 
-  components: {},
+  components: { Button },
 
   data() {
     return {

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -5,7 +5,7 @@
         <v-toolbar color="primary" dark flat>
           <v-toolbar-title>Register</v-toolbar-title>
           <v-spacer></v-spacer>
-          <v-btn text @click="goToWcaAuth()">
+          <Button variant="text" @click="goToWcaAuth()">
             <img
               src="../static/WCAlogo_notext.svg"
               alt=""
@@ -13,8 +13,8 @@
               class="pr-2"
             />
             WCA Login
-          </v-btn>
-          <v-btn text nuxt to="/login">Login</v-btn>
+          </Button>
+          <Button variant="text" nuxt to="/login">Login</Button>
         </v-toolbar>
         <RegisterInterface
           @login-success="handleLoginSuccess"
@@ -27,12 +27,14 @@
 <script>
 import authService from '~/services/auth.js'
 import RegisterInterface from '~/components/interface/auth/registerInterface.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   middleware: 'router-auth',
 
   components: {
     RegisterInterface,
+    Button,
   },
 
   data() {

--- a/pages/room-stream.vue
+++ b/pages/room-stream.vue
@@ -116,7 +116,7 @@
               </div>
             </v-col>
           </v-row>
-            <!--
+          <!--
             <v-col xl="9" lg="12">
               <v-card outlined tile>
                 <v-simple-table id="roomResults" fixed-header>
@@ -322,11 +322,11 @@
     </v-layout>
     <v-footer v-if="room" absolute fixed height="auto">
       <div class="text-center pt-1" style="width: 100%;">
-        <v-btn id="v-step-share" @click="copyShareLink()">Share Link</v-btn>
-        <v-btn @click="openViewRoundsDialog()">All Rounds</v-btn>
-        <v-btn id="v-step-settings" icon @click="openEditRoomSettingsDialog()">
+        <Button id="v-step-share" @click="copyShareLink()">Share Link</Button>
+        <Button @click="openViewRoundsDialog()">All Rounds</Button>
+        <Button id="v-step-settings" icon @click="openEditRoomSettingsDialog()">
           <v-icon>mdi-cog</v-icon>
-        </v-btn>
+        </Button>
       </div>
       <v-row justify="center" class="pt-1">
         <span class="caption grey--text">
@@ -394,9 +394,9 @@ import ViewRoundDialog from '~/components/dialog/round/viewRoundDialog'
 import ViewRoundsDialog from '~/components/dialog/round/viewRoundsDialog'
 import EditRoomSettingsDialog from '~/components/dialog/misc/editRoomSettingsDialog'
 import ViewAccumulatedResultDialog from '~/components/dialog/accumulated/viewAccumulatedResultDialog'
-import ScrambleDisplay from '~/components/shared/scrambleDisplay.vue'
 import Scramble from '~/components/shared/scramble'
 import { mapGetters } from 'vuex'
+import Button from '~/components/shared/button.vue'
 
 export default {
   layout: 'lite',
@@ -408,8 +408,8 @@ export default {
     ViewRoundsDialog,
     EditRoomSettingsDialog,
     ViewAccumulatedResultDialog,
-    ScrambleDisplay,
     Scramble,
+    Button,
   },
 
   data() {

--- a/pages/room.vue
+++ b/pages/room.vue
@@ -155,7 +155,9 @@
                           >mdi-crown</v-icon
                         >
                         <v-icon
-                          v-if="room.manager && room.manager.id == props.item.id"
+                          v-if="
+                            room.manager && room.manager.id == props.item.id
+                          "
                           color="green"
                           small
                           title="Room Manager"
@@ -175,7 +177,9 @@
                           >mdi-sleep</v-icon
                         >
                         <v-icon
-                          v-else-if="props.item.cuber.pivot.type === 'SPECTATING'"
+                          v-else-if="
+                            props.item.cuber.pivot.type === 'SPECTATING'
+                          "
                           small
                           title="Spectating"
                           >mdi-eye</v-icon
@@ -205,9 +209,14 @@
                         <span
                           class="pointer-cursor"
                           @click="
-                            openViewAccumulatedResultDialog(props.item.id, accItem)
+                            openViewAccumulatedResultDialog(
+                              props.item.id,
+                              accItem,
+                            )
                           "
-                          v-html="renderAccumulatedResults(props.item.id, accItem)"
+                          v-html="
+                            renderAccumulatedResults(props.item.id, accItem)
+                          "
                         ></span>
                       </td>
                     </tr>
@@ -278,24 +287,24 @@
         </v-expansion-panel>
       </v-expansion-panels>
       <div class="text-center pt-1" style="width: 100%;">
-        <v-btn
+        <Button
           v-if="isRoomManager"
           id="v-step-startroom"
           :loading="loading.startingNextRound"
           color="primary"
           @click="startNextRound()"
-          >{{ activeRound ? 'Start Next Round' : 'Start Room' }}</v-btn
+          >{{ activeRound ? 'Start Next Round' : 'Start Room' }}</Button
         >
         <span v-else id="v-step-startroom">&nbsp;</span>
         <v-menu offset-y top>
           <template v-slot:activator="{ on }">
-            <v-btn
+            <Button
               id="v-step-cuberstatus"
               :loading="loading.updateRoomStatus"
               v-on="on"
             >
               Your Status: {{ cuberStatusMap[currentUserStatus] }}
-            </v-btn>
+            </Button>
           </template>
           <v-list>
             <v-list-item
@@ -307,23 +316,23 @@
             </v-list-item>
           </v-list>
         </v-menu>
-        <v-btn id="v-step-share" @click="copyShareLink()">Share Link</v-btn>
-        <v-btn @click="openViewRoundsDialog()">All Rounds</v-btn>
-        <v-btn @click="startTutorial()">Tutorial</v-btn>
-        <v-btn @click="openStreamerWindow()">
+        <Button id="v-step-share" @click="copyShareLink()">Share Link</Button>
+        <Button @click="openViewRoundsDialog()">All Rounds</Button>
+        <Button @click="startTutorial()">Tutorial</Button>
+        <Button @click="openStreamerWindow()">
           <v-icon left>mdi-open-in-new</v-icon>
           Streamer Window
-        </v-btn>
-        <v-btn @click="toggleChat()">
+        </Button>
+        <Button @click="toggleChat()">
           <v-icon left>mdi-chat</v-icon>
           Chat Room
           <span v-if="chatUnreadMessages">
             ({{ chatUnreadMessages }} New Messages)
           </span>
-        </v-btn>
-        <v-btn id="v-step-settings" icon @click="openEditRoomSettingsDialog()">
+        </Button>
+        <Button id="v-step-settings" icon @click="openEditRoomSettingsDialog()">
           <v-icon>mdi-cog</v-icon>
-        </v-btn>
+        </Button>
       </div>
       <v-row justify="center" class="pt-1">
         <span class="caption grey--text">
@@ -402,6 +411,7 @@ import ViewAccumulatedResultDialog from '~/components/dialog/accumulated/viewAcc
 import ScrambleDisplay from '~/components/shared/scrambleDisplay.vue'
 import Scramble from '~/components/shared/scramble'
 import { mapGetters } from 'vuex'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
@@ -414,6 +424,7 @@ export default {
     ViewAccumulatedResultDialog,
     ScrambleDisplay,
     Scramble,
+    Button,
   },
 
   data() {

--- a/pages/rooms.vue
+++ b/pages/rooms.vue
@@ -20,19 +20,14 @@
                 <v-icon left>mdi-google-classroom</v-icon>
                 <v-toolbar-title>Rooms</v-toolbar-title>
                 <v-divider class="mx-4" inset vertical></v-divider>
-                <v-btn
-                  color="primary"
-                  dark
-                  class="mb-2"
-                  @click="openAddRoomDialog()"
-                >
+                <Button class="mb-2" @click="openAddRoomDialog()">
                   <v-icon left>mdi-plus</v-icon>
                   New Room
-                </v-btn>
+                </Button>
                 <v-spacer></v-spacer>
-                <v-btn icon @click="reset()">
+                <Button icon @click="reset()">
                   <v-icon>mdi-refresh</v-icon>
-                </v-btn>
+                </Button>
               </v-toolbar>
               <v-expansion-panels>
                 <v-expansion-panel>
@@ -187,15 +182,10 @@
               <div>
                 No rooms matched your filters
                 <br />
-                <v-btn
-                  color="primary"
-                  class="my-2"
-                  dark
-                  @click="openAddRoomDialog()"
-                >
+                <Button class="my-2" @click="openAddRoomDialog()">
                   <v-icon left>mdi-plus</v-icon>
                   Create a Room
-                </v-btn>
+                </Button>
               </div>
             </template>
           </v-data-table>
@@ -240,6 +230,7 @@ import DeleteRoomDialog from '~/components/dialog/room/deleteRoomDialog.vue'
 import InputRoomSecretDialog from '~/components/dialog/room/inputRoomSecretDialog.vue'
 import EventLabel from '~/components/shared/eventLabel.vue'
 import CuberAvatar from '~/components/shared/cuberAvatar.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
@@ -249,6 +240,7 @@ export default {
     InputRoomSecretDialog,
     EventLabel,
     CuberAvatar,
+    Button,
   },
 
   data() {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -6,7 +6,7 @@
           <v-toolbar color="primary" dark flat>
             <v-toolbar-title>User Settings</v-toolbar-title>
             <v-spacer></v-spacer>
-            <v-btn text @click="goToWcaAuth()">
+            <Button variant="text" @click="goToWcaAuth()">
               <img
                 src="../static/WCAlogo_notext.svg"
                 alt=""
@@ -14,7 +14,7 @@
                 class="pr-2"
               />
               Link WCA Account
-            </v-btn>
+            </Button>
           </v-toolbar>
           <v-card-text>
             <v-text-field
@@ -60,11 +60,8 @@
           </v-card-text>
           <v-card-actions>
             <v-spacer></v-spacer>
-            <v-btn
-              color="primary"
-              :loading="loading.submitting"
-              @click="handleSubmit()"
-              >Save Changes</v-btn
+            <Button :loading="loading.submitting" @click="handleSubmit()"
+              >Save Changes</Button
             >
           </v-card-actions>
         </v-card>
@@ -79,9 +76,10 @@ import { UPDATE_CUBER_MUTATION } from '~/gql/mutation/cuber.js'
 import sharedService from '~/services/shared.js'
 import { countriesArray } from '~/services/constants.js'
 import authService from '~/services/auth.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
-  components: {},
+  components: { Button },
 
   data() {
     return {

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -9,9 +9,9 @@
               Global Stats
             </v-toolbar-title>
             <v-spacer></v-spacer>
-            <v-btn icon @click="reset()">
+            <Button icon @click="reset()">
               <v-icon>mdi-refresh</v-icon>
-            </v-btn>
+            </Button>
           </v-toolbar>
           <v-tabs v-model="tab">
             <v-tab v-for="item in tabItems" :key="item.tab">
@@ -70,11 +70,13 @@ import { booleanOptionsArray } from '~/services/constants.js'
 import { EVENTS_QUERY } from '~/gql/query/event.js'
 import ViewCuberSolvesInterface from '~/components/interface/viewCuberSolvesInterface.vue'
 import EventLabel from '~/components/shared/eventLabel.vue'
+import Button from '~/components/shared/button.vue'
 
 export default {
   components: {
     ViewCuberSolvesInterface,
     EventLabel,
+    Button,
   },
 
   data() {

--- a/pages/update-password.vue
+++ b/pages/update-password.vue
@@ -6,7 +6,7 @@
           <v-toolbar color="primary" dark flat>
             <v-toolbar-title>Update Password</v-toolbar-title>
             <v-spacer></v-spacer>
-            <v-btn text nuxt to="/login">Login</v-btn>
+            <Button variant="text" nuxt to="/login">Login</Button>
           </v-toolbar>
           <v-card-text>
             <v-text-field
@@ -36,11 +36,8 @@
           </v-card-text>
           <v-card-actions>
             <v-spacer></v-spacer>
-            <v-btn
-              color="primary"
-              :disabled="loading.submitting"
-              @click="handleSubmit()"
-              >Update Password</v-btn
+            <Button :disabled="loading.submitting" @click="handleSubmit()"
+              >Update Password</Button
             >
           </v-card-actions>
         </v-card>
@@ -52,9 +49,10 @@
 <script>
 import { UPDATE_FORGOTTEN_PASSWORD_MUTATION } from '~/gql/mutation/auth.js'
 import sharedService from '~/services/shared.js'
+import Button from '~/components/shared/button.vue'
 
 export default {
-  components: {},
+  components: { Button },
 
   data() {
     return {


### PR DESCRIPTION
## Description
Customizing colors in Vuetify is not easy!
I updated the color palette to make sure that everything is more readable on the website, but it's impossible to customize the button's text without doing a lot of manual overwrites. So I ended up having to create a new component for the button in order to make things work there.

### Palette change
The main change is that blue has been lighten in the dark mode and brightened in the light in order to have better contrast. The secondary color has also been redefined to purple (but it's not used anywhere in the application, as far as I can tell).
The changes are visible over the whole application, but here is an example:
| Before | After |
|----|----|
|![light-theme-before](https://user-images.githubusercontent.com/3652786/85234017-e3a2ee80-b40a-11ea-8d81-f16901fcf823.PNG) |![light-theme-after](https://user-images.githubusercontent.com/3652786/85234019-e7367580-b40a-11ea-883a-c05bf90c00da.PNG)|
|![dark-theme-before](https://user-images.githubusercontent.com/3652786/85234023-ebfb2980-b40a-11ea-9a28-805e4e58817c.PNG)|![dark-theme-after](https://user-images.githubusercontent.com/3652786/85234027-eef61a00-b40a-11ea-94cd-3710b4d0c602.PNG)|




### Button component
It's going to be important to remember to use this button component in the future, rather that the Vuetify's one. I could try to write an eslint rule or some kind of CI test that could detect usages of Vuetify's button instead of the custom component.

I think this covers all the use cases that we have of the button, and I did as thorough testing as possible, but there were a lot of buttons in the application, so it's possible I missed something.

#### Props: 
| name  |  usage  | type |  default|
|:---|:---|:---|:---|
| **color**  |  Used to define the color of the button | One of `primary`, `secondary`, `accent`, `info`, `success`, `warning`, `error`   | `primary`  | 
|**variant**| Used to define the variant of the button | One of `contained`, `outlined`, `text` | `contained`|
|**inversed**| Used to inverse the background color and text color. This is useful if the button needs to be displayed on a background of the same color. | Boolean | `false` |
|**icon**| Used to signal that the button is to be used as an icon. The button will inherit the text's color | Boolean | `false`|

#### Examples:
|Dark mode|Light mode|
|----|---|
|![dark-palette](https://user-images.githubusercontent.com/3652786/85233812-7e023280-b409-11ea-98b5-71bb6f7c168c.png)|![light palette](https://user-images.githubusercontent.com/3652786/85233814-7f335f80-b409-11ea-970a-3049e140012f.png)|


